### PR TITLE
Use upstream che-editor.yaml

### DIFF
--- a/.che/che-editor.yaml
+++ b/.che/che-editor.yaml
@@ -1,1 +1,2 @@
 id: che-incubator/che-code/insiders
+registryUrl: https://eclipse-che.github.io/che-plugin-registry/main/v3


### PR DESCRIPTION
Change the che-editor.yaml to point to the Eclipse Che upstream registry so that it get the latest development build of VS Code.